### PR TITLE
setup.py: tests directory will not be installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author_email='timothee.peignier@tryphon.org',
     url='https://github.com/cyberdelia/atomic',
     license='MIT',
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests',)),
     zip_safe=False,
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
Hello. setup.py may include tests directory as a package. So, besides atomic package, tests package will be installed and this definitely a bad behavior. An applied patch fixes this.